### PR TITLE
Add support for pushy.me

### DIFF
--- a/lib/pigeon/apns_worker.ex
+++ b/lib/pigeon/apns_worker.ex
@@ -2,7 +2,7 @@ defmodule Pigeon.APNSWorker do
   @moduledoc """
     Handles all APNS request and response parsing over an HTTP2 connection.
   """
-  use Pigeon.GenericH2Worker, ping_interval: 600_000
+  use Pigeon.GenericH2Worker, ping_interval: 600_000, http_client: Pigeon.H2
   require Logger
 
   def host(config) do
@@ -81,7 +81,7 @@ defmodule Pigeon.APNSWorker do
     end
   end
 
-  def req_path(notification) do
+  def req_path(_config, notification) do
     "/3/device/#{notification.device_token}"
   end
 

--- a/lib/pigeon/gcm_worker.ex
+++ b/lib/pigeon/gcm_worker.ex
@@ -2,7 +2,7 @@ defmodule Pigeon.GCMWorker do
   @moduledoc """
     Handles all FCM request and response parsing over an HTTP2 connection.
   """
-  use Pigeon.GenericH2Worker, ping_interval: 60_000
+  use Pigeon.GenericH2Worker, ping_interval: 60_000, http_client: Pigeon.H2
   alias Pigeon.GCM.NotificationResponse
   require Logger
 
@@ -30,7 +30,7 @@ defmodule Pigeon.GCMWorker do
      {"accept", "application/json"}]
   end
 
-  def req_path(_notification) do
+  def req_path(_config, _notification) do
     "/fcm/send"
   end
 

--- a/lib/pigeon/http_1.ex
+++ b/lib/pigeon/http_1.ex
@@ -1,0 +1,35 @@
+defmodule Pigeon.HTTP_1 do
+  require Logger
+
+  def open(_uri, _port, _opts \\ []) do
+    {:ok, self()}
+  end
+
+  def close(_conn) do
+    :ok
+  end
+
+  def post(_conn, uri, path, headers, body) do
+    url = "https://" <> uri <> "/" <> path
+    case HTTPoison.post(url, body, headers) do
+      {:ok, response} ->
+        stream_id = :base64.encode(:erlang.term_to_binary(response))
+        send(self(), {:END_STREAM, stream_id})
+        {:ok, stream_id}
+      {:error, _} = e ->
+        e
+    end
+  end
+
+  def receive(_conn, stream_id) do
+    response = :erlang.binary_to_term(:base64.decode(stream_id))
+    headers = response.headers ++ [
+      {":status", Integer.to_string(response.status_code)}
+    ]
+    {:ok, {headers, response.body}}
+  end
+
+  def ping(_conn) do
+    :ok
+  end
+end

--- a/lib/pigeon/pushy_worker.ex
+++ b/lib/pigeon/pushy_worker.ex
@@ -1,0 +1,60 @@
+defmodule Pigeon.PushyWorker do
+  @moduledoc """
+    Handles all Pushy request and response parsing over an HTTP1.1 connection.
+  """
+  use Pigeon.GenericH2Worker, ping_interval: 60_000, http_client: Pigeon.HTTP_1
+  alias Pigeon.GCM.NotificationResponse
+  require Logger
+
+  def default_name, do: :pushy_default
+
+  def host(config) do
+    config[:endpoint] || "api.pushy.me"
+  end
+
+  def port(config) do
+    config[:port]     || 443
+  end
+
+  def socket_options(_config) do
+    {:ok, []}
+  end
+
+  def encode_notification({_registration_ids, notification}) do
+    notification
+  end
+
+  def req_headers(config, _notification) do
+    [
+      {"content-type", "application/json"},
+      {"accept", "application/json"}
+    ]
+  end
+
+  def req_path(config, _notification) do
+    "push?api_key=#{config[:key]}"
+  end
+
+  defp parse_error(_notification, _headers, body) do
+    {:ok, response} = Poison.decode(body)
+    response["error"]
+  end
+
+  defp parse_response({registration_ids, payload}, _headers, body) do
+    result = Poison.decode! body
+    parse_result(registration_ids, result)
+  end
+
+  def parse_result(ids, result) do
+    case result["success"] do
+      true ->
+        %Pigeon.GCM.NotificationResponse{ok: ids, message_id: result["id"]}
+      false ->
+        %Pigeon.GCM.NotificationResponse{error: ids}
+    end
+  end
+
+  def error_msg(code, error) do
+    Pigeon.GCMWorker.error_msg(code, error)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -30,7 +30,7 @@ defmodule Pigeon.Mixfile do
 
   defp deps do
     [{:poison, "~> 2.0 or ~> 3.0"},
-    {:httpoison, "~> 0.7"},
+    {:httpoison, "~> 1.4"},
     {:chatterbox, github: "rslota/chatterbox", tag: "20f0096"},
     {:poolboy, "~> 1.5"},
     {:dogma, "~> 0.1", only: :dev},


### PR DESCRIPTION
Pushy push service is supported by `Pigeon.PushyWorker` and `Pigeon.GCM`
modules. We're reusing notification building capabilities `Pigeon.GCM`
as the API of Pushy is the same as FCM Legacy.